### PR TITLE
Fix PurgeCSS integration not finding CSS and HTML content files on Windows

### DIFF
--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -13,12 +13,23 @@ export type PurgeCSSOptions = {
   blocklist?: StringRegExpArray;
 };
 
+function handleWindowsPath(outputPath: string): string {
+  if(process.platform !== 'win32') return outputPath;
+
+  if(outputPath.endsWith('\\')){
+    outputPath = outputPath.substring(0, outputPath.length - 1);
+  }
+  outputPath = outputPath.replaceAll('\\', '/');
+
+  return outputPath;
+}
+
 export default function (options: PurgeCSSOptions = {}): AstroIntegration {
   return {
     name: 'astro-purgecss',
     hooks: {
       'astro:build:done': async ({ dir }) => {
-        const outDir = fileURLToPath(dir);
+        const outDir = handleWindowsPath(fileURLToPath(dir));
         const purged = await new PurgeCSS().purge({
           ...options,
           content: [`${outDir}/**/*.html`],


### PR DESCRIPTION
This should close #80.

A fix for `astro-purgecss`, which patches the two globs that find CSS and HTML files for PurgeCSS to analyze, but only when on Windows. :)