### PR TITLE
chore(fix) fixed purgecss not reading CSS classes from javascript fra…

### DIFF
--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -32,7 +32,10 @@ export default function (options: PurgeCSSOptions = {}): AstroIntegration {
         const outDir = handleWindowsPath(fileURLToPath(dir));
         const purged = await new PurgeCSS().purge({
           ...options,
-          content: [`${outDir}/**/*.html`],
+          content: [
+            `${outDir}/**/*.html`,
+            `${outDir}/**/*.js`
+        ],
           css: [`${outDir}/**/*.css`],
           defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || []
         });


### PR DESCRIPTION
When using this library I found that when using `@astro/vuejs` that the CSS classes defined in `javascript` files as components are being purged, I fixed this in my own project by adding the `.js` filetype to the `content` of the purge config. 