### PR TITLE
Add includeSource option to astro-purgecss

### DIFF
--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -11,6 +11,7 @@ export type PurgeCSSOptions = {
   variables?: boolean;
   safelist?: UserDefinedSafelist;
   blocklist?: StringRegExpArray;
+  includeSource?: StringRegExpArray;
 };
 
 function handleWindowsPath(outputPath: string): string {
@@ -34,7 +35,8 @@ export default function (options: PurgeCSSOptions = {}): AstroIntegration {
           ...options,
           content: [
             `${outDir}/**/*.html`,
-            `${outDir}/**/*.js`
+            `${outDir}/**/*.js`,
+            options.includeSource ? `./src/**/*.{vue,astro}` : undefined
         ],
           css: [`${outDir}/**/*.css`],
           defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || []


### PR DESCRIPTION
Hello,

I am using Astro + Vue 3 + PrimeVue and I had a problem using partial pre-rendering.

It looks astro-purgecss only works for pre-rendered pages and all the ssr-rendered page are ignored : so the css is broken on all ssr pages but not pre-rendered ones.

For users with hybrid pre-rendering (ssr) I suggest to add the parameter `includeSource` allowing us to include the source files (astro and vue in my case, but we may add more extensions ?).

What is your opinion about this addition ?