### PR TITLE
SSR compatibility : add options.content to be modified by the end user

### DIFF
--- a/packages/astro-purgecss/README.md
+++ b/packages/astro-purgecss/README.md
@@ -67,11 +67,18 @@ export default defineConfig({
       fontFace: true,
       keyframes: true,
       safelist: ['random', 'yep', 'button', /^nav-/],
-      blocklist: ['usedClass', /^nav-/]
+      blocklist: ['usedClass', /^nav-/],
+      contents: [
+        process.cwd() + '/src/**/*.{astro,vue}', // Watching astro and vue sources (for SSR, read the note below)
+      ],
     })
   ]
 });
 ```
+
+> **Note**
+>
+> If you are using **Astro SSR** in your project, you must add your astro and framework sources files into the `content` option (see in the example). Otherwise, as the package only look at the final build sent to the client, with SSR, some pages may not be included and may break your CSS.
 
 ### Available Options
 
@@ -86,6 +93,7 @@ export type PurgeCSSOptions = {
   variables?: boolean; // removes any unused CSS variables if set to true
   safelist?: UserDefinedSafelist; // indicates which selectors are safe to leave in the final CSS
   blocklist?: StringRegExpArray; // blocks the CSS selectors from appearing in the final output CSS
+  content?: Array<string | RawContent>;
 };
 ```
 
@@ -95,7 +103,7 @@ We have also setup an example repository available here: [example-purgecss](../.
 
 ### Caveats
 
-- Certain options (ex: `css`, `content`), are not allowed to be passed in your `astro.config.mjs` config file, to not interfere with the internals of this integration.
+- Options `css` is not allowed to be passed in your `astro.config.mjs` config file, to not interfere with the internals of this integration.
 
 - If you are using `tailwind.css`, please read about purge limitations in this guide [writing-purgeable-html](https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html)
 

--- a/packages/astro-purgecss/README.md
+++ b/packages/astro-purgecss/README.md
@@ -68,7 +68,7 @@ export default defineConfig({
       keyframes: true,
       safelist: ['random', 'yep', 'button', /^nav-/],
       blocklist: ['usedClass', /^nav-/],
-      contents: [
+      content: [
         process.cwd() + '/src/**/*.{astro,vue}', // Watching astro and vue sources (for SSR, read the note below)
       ],
     })
@@ -103,7 +103,7 @@ We have also setup an example repository available here: [example-purgecss](../.
 
 ### Caveats
 
-- Options `css` is not allowed to be passed in your `astro.config.mjs` config file, to not interfere with the internals of this integration.
+- Some options are not allowed to be passed in your `astro.config.mjs` config file, to not interfere with the internals of this integration.
 
 - If you are using `tailwind.css`, please read about purge limitations in this guide [writing-purgeable-html](https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html)
 

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegration } from 'astro';
-import { PurgeCSS, StringRegExpArray, UserDefinedSafelist } from 'purgecss';
+import { PurgeCSS, RawContent, StringRegExpArray, UserDefinedSafelist } from 'purgecss';
 import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -11,6 +11,7 @@ export type PurgeCSSOptions = {
   variables?: boolean;
   safelist?: UserDefinedSafelist;
   blocklist?: StringRegExpArray;
+  content?: Array<string | RawContent>;
 };
 
 function handleWindowsPath(outputPath: string): string {

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -34,7 +34,8 @@ export default function (options: PurgeCSSOptions = {}): AstroIntegration {
           ...options,
           content: [
             `${outDir}/**/*.html`,
-            `${outDir}/**/*.js`
+            `${outDir}/**/*.js`,
+            ...options.content || []
         ],
           css: [`${outDir}/**/*.css`],
           defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || []


### PR DESCRIPTION
As mentionned with a precedent (and removed) draft. This is my contribution for adding Astro SSR compatibility.

Reminder of the background : SSR is broken as the plugin only look for the client final build and not the project sources.