### PR TITLE
Allow overriding purgecss options

### DIFF
--- a/.changeset/green-houses-laugh.md
+++ b/.changeset/green-houses-laugh.md
@@ -1,0 +1,5 @@
+---
+"astro-purgecss": minor
+---
+
+Allow to override any of purgecss options


### PR DESCRIPTION
this pull request updates purgecss regex to avoid deleting styles that are actually in use.
https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html

UPDATE:
it was decided to allow providing custom options to override existing ones instead of introducing a breaking change
