### PR TITLE
Update README.md to include info on custom extractors

### DIFF
--- a/packages/astro-purgecss/README.md
+++ b/packages/astro-purgecss/README.md
@@ -79,7 +79,15 @@ export default defineConfig({
       blocklist: ['usedClass', /^nav-/],
       content: [
         process.cwd() + '/src/**/*.{astro,vue}' // Watching astro and vue sources (for SSR, read the note below)
-      ]
+      ],
+      extractors: [
+        {
+          // Example using a taiwindcss compatible class extractor
+          extractor: (content) =>
+            content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
+          extensions: ["astro", "html"],
+        },
+      ],
     })
   ]
 });
@@ -103,6 +111,11 @@ export type PurgeCSSOptions = {
   safelist?: UserDefinedSafelist; // indicates which selectors are safe to leave in the final CSS
   blocklist?: StringRegExpArray; // blocks the CSS selectors from appearing in the final output CSS
   content?: Array<string | RawContent>;
+  extractors?:  // provides custom functions to extract CSS classes in specific ways (eg. when using tailwind.css) 
+    Array<{
+      extractor: (content: string) => string[]; // matched css classes
+      extensions: string[]; // file extensions for which this extractor is to be used
+    }>;
 };
 ```
 
@@ -116,7 +129,23 @@ We have also setup an example repository available here: [example-purgecss](../.
 
 - If you are using [inline styles](https://docs.astro.build/en/guides/styling/#scoped-styles), this plugin won't be able to purge those css rules, due to astro's way of handling scoped css rules.
 
-- If you are using `tailwind.css`, please read about purge limitations in this guide [writing-purgeable-html](https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html)
+
+- If you are using `tailwind.css`, please read about purge limitations in this guide [writing-purgeable-html](https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html). You may also need a custom class extractor compatible with arbitrary and container based `tailwind.css` classes. For example:
+```js
+export default defineConfig({
+  integrations: [
+    purgecss({
+      extractors: [
+        {
+          extractor: (content) =>
+            content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [],
+          extensions: ["astro", "html"],
+        },
+      ],
+    }),
+  ],
+});
+```
 
 ## Changelog
 


### PR DESCRIPTION
After struggling setting up astro-purgecss (issue #385) together with tailwind.css, I'm suggesting with this PR to add some info in the README.md to help future package users to setup astro-purgecss correctly with tailwind.css.