### PR TITLE
Document how to preserve Astro view transitions animations - fix #438

### DIFF
--- a/packages/astro-purgecss/README.md
+++ b/packages/astro-purgecss/README.md
@@ -130,6 +130,20 @@ We have also setup an example repository available here: [example-purgecss](../.
 - If you are using [inline styles](https://docs.astro.build/en/guides/styling/#scoped-styles), this plugin won't be able to purge those css rules, due to astro's way of handling scoped css rules.
 
 
+- If you are using Astro view transitions, use the following options so that purgecss keeps the corresponding animations:
+```diff
+export default defineConfig({
+  integrations: [
+    purgecss({
++      keyframes: false
++      , safelist: {
++        greedy: [/*astro*/]
++      }
+    }),
+  ],
+});
+```
+
 - If you are using `tailwind.css`, please read about purge limitations in this guide [writing-purgeable-html](https://v2.tailwindcss.com/docs/optimizing-for-production#writing-purgeable-html). You may also need a custom class extractor compatible with arbitrary and container based `tailwind.css` classes. For example:
 ```js
 export default defineConfig({


### PR DESCRIPTION
This edit documents how to prevent `astro-purgecss` from removing the view transition animation code.