### PR TITLE
fix: astro-purgecss is modifying files keeping old hash

### DIFF
--- a/packages/astro-purgecss/package.json
+++ b/packages/astro-purgecss/package.json
@@ -3,7 +3,7 @@
   "description": "Remove unused CSS rules from your final Astro bundle",
   "version": "4.1.1",
   "scripts": {
-    "build": "astro-build --src src/index.ts",
+    "build": "astro-build --src src/index.ts src/utils.ts",
     "typecheck": "tsc --declaration --emitDeclarationOnly"
   },
   "type": "module",

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -1,7 +1,9 @@
 import type { AstroIntegration } from 'astro';
-import { PurgeCSS, type UserDefinedOptions } from 'purgecss';
-import { writeFile } from 'node:fs/promises';
+import { promises as fs } from 'node:fs';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PurgeCSS, type UserDefinedOptions } from 'purgecss';
 
 export interface PurgeCSSOptions extends Partial<UserDefinedOptions> {}
 
@@ -14,6 +16,51 @@ function handleWindowsPath(outputPath: string): string {
   outputPath = outputPath.replaceAll('\\', '/');
 
   return outputPath;
+}
+
+async function getHashFromFile(fileBuffer: BufferSource) {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', fileBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return hashHex.substring(0, 7);
+}
+
+async function replaceStringInFile(
+  filePath: string,
+  searchString: string,
+  replaceString: string
+): Promise<void> {
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    if (data.includes(searchString)) {
+      const updatedData = data.split(searchString).join(replaceString);
+      await fs.writeFile(filePath, updatedData, 'utf8');
+    }
+  } catch (error) {
+    console.error(`Error processing file ${filePath}:`, error);
+  }
+}
+
+async function processDirectory(
+  dir: string,
+  searchString: string,
+  replaceString: string
+): Promise<void> {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await processDirectory(fullPath, searchString, replaceString);
+      } else if (entry.isFile()) {
+        await replaceStringInFile(fullPath, searchString, replaceString);
+      }
+    }
+  } catch (error) {
+    console.error(`Error processing directory ${dir}:`, error);
+  }
 }
 
 export default function (options: PurgeCSSOptions = {}): AstroIntegration {
@@ -30,12 +77,29 @@ export default function (options: PurgeCSSOptions = {}): AstroIntegration {
             `${outDir}/**/*.html`,
             `${outDir}/**/*.js`,
             ...(options.content || [])
-          ],
+          ]
         });
         await Promise.all(
           purged
             .filter(({ file }) => file?.endsWith('.css'))
-            .map(async ({ css, file }) => await writeFile(file!, css))
+            .map(async ({ css, file }) => {
+              if (!file) return;
+              await writeFile(file, css);
+
+              // Get content hash
+              const hash = await getHashFromFile(await readFile(file));
+
+              // Rename file
+              const newPath = file.slice(0, -12) + hash + '.css';
+              await rename(file, newPath);
+
+              // Replace old name references by newPath
+              const oldName = file.split('/').pop();
+              const newName = newPath.split('/').pop();
+              if (oldName && newName) {
+                await processDirectory(outDir + '../', oldName, newName);
+              }
+            })
         );
       }
     }

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -1,59 +1,12 @@
 import type { AstroIntegration } from 'astro';
 import { createHash } from 'crypto';
-import { readdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PurgeCSS, type UserDefinedOptions } from 'purgecss';
+import { handleWindowsPath, replaceStringInDirectory } from './utils';
 
 export interface PurgeCSSOptions extends Partial<UserDefinedOptions> {}
-
-function handleWindowsPath(outputPath: string): string {
-  if (process.platform !== 'win32') return outputPath;
-
-  if (outputPath.endsWith('\\')) {
-    outputPath = outputPath.substring(0, outputPath.length - 1);
-  }
-  outputPath = outputPath.replaceAll('\\', '/');
-
-  return outputPath;
-}
-
-async function replaceStringInFile(
-  filePath: string,
-  searchValue: string,
-  replaceValue: string
-) {
-  try {
-    const fileContent = await readFile(filePath, 'utf8');
-    if (fileContent.includes(searchValue)) {
-      const re = new RegExp(searchValue, 'g');
-      const newContent = fileContent.replace(re, replaceValue);
-      await writeFile(filePath, newContent, 'utf8');
-    }
-  } catch (err) {
-    console.error(`Error processing file ${filePath}: ${err}`);
-  }
-}
-
-async function replaceStringInDirectory(
-  directory: string,
-  searchValue: string,
-  replaceValue: string
-) {
-  try {
-    const files = await readdir(directory, { withFileTypes: true });
-    for (const file of files) {
-      const fullPath = path.join(directory, file.name);
-      if (file.isDirectory()) {
-        await replaceStringInDirectory(fullPath, searchValue, replaceValue);
-      } else if (file.isFile()) {
-        await replaceStringInFile(fullPath, searchValue, replaceValue);
-      }
-    }
-  } catch (err) {
-    console.error(`Error processing directory ${directory}: ${err}`);
-  }
-}
 
 export default function (options: PurgeCSSOptions = {}): AstroIntegration {
   return {

--- a/packages/astro-purgecss/src/utils.ts
+++ b/packages/astro-purgecss/src/utils.ts
@@ -1,0 +1,50 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export function handleWindowsPath(outputPath: string): string {
+  if (process.platform !== 'win32') return outputPath;
+
+  if (outputPath.endsWith('\\')) {
+    outputPath = outputPath.substring(0, outputPath.length - 1);
+  }
+  outputPath = outputPath.replaceAll('\\', '/');
+
+  return outputPath;
+}
+
+export async function replaceStringInFile(
+  filePath: string,
+  searchValue: string,
+  replaceValue: string
+) {
+  try {
+    const fileContent = await readFile(filePath, 'utf8');
+    if (fileContent.includes(searchValue)) {
+      const re = new RegExp(searchValue, 'g');
+      const newContent = fileContent.replace(re, replaceValue);
+      await writeFile(filePath, newContent, 'utf8');
+    }
+  } catch (err) {
+    console.error(`Error processing file ${filePath}: ${err}`);
+  }
+}
+
+export async function replaceStringInDirectory(
+  directory: string,
+  searchValue: string,
+  replaceValue: string
+) {
+  try {
+    const files = await readdir(directory, { withFileTypes: true });
+    for (const file of files) {
+      const fullPath = path.join(directory, file.name);
+      if (file.isDirectory()) {
+        await replaceStringInDirectory(fullPath, searchValue, replaceValue);
+      } else if (file.isFile()) {
+        await replaceStringInFile(fullPath, searchValue, replaceValue);
+      }
+    }
+  } catch (err) {
+    console.error(`Error processing directory ${directory}: ${err}`);
+  }
+}


### PR DESCRIPTION
Proof of concept that tries to fix #450. It does the following:

- Generates a hash from purged CSS content (the first 8 characters from SHA256).
- Renames the CSS file, replacing the hash.
- Looks for references to the old name in the /dist folder and replaces them with the new one.