### PR TITLE
[astro-purgecss] Handle custom 404 page

### DIFF
--- a/.changeset/dry-kings-run.md
+++ b/.changeset/dry-kings-run.md
@@ -1,0 +1,5 @@
+---
+'astro-purgecss': minor
+---
+
+Added dedicated handling for custom 404 error pages in build output paths, ensuring proper file generation at root level

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -152,6 +152,11 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
                 return join(outDir, 'index.html');
               }
 
+              // Handle custom 404 page (https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page)
+              if (pathname === '404/') {
+                return join(outDir, '404.html');
+              }
+
               switch (config.build.format) {
                 case 'file':
                   // Format: /blog -> /blog.html

--- a/packages/astro-purgecss/src/utils.ts
+++ b/packages/astro-purgecss/src/utils.ts
@@ -18,7 +18,6 @@ export async function writeFileContent(filePath: string, content: string) {
     await writeFile(filePath, content, 'utf8');
   } catch (err) {
     error(`Error writing file ${filePath}: ${err}`);
-    return '';
   }
 }
 
@@ -40,7 +39,7 @@ export function generateFileHash(filePath: string, content: string) {
   const hash = createHash('sha256').update(content).digest('hex').slice(0, 8);
 
   // Generate new file name with hash
-  // Astro orignal hash is 8 characters long
+  // Astro original hash is 8 characters long
   return `${filePath.slice(0, -13)}.${hash}.css`;
 }
 


### PR DESCRIPTION
### Description

This PR adds special handling for the `404` custom error page in Astro integration, ensuring proper file path generation based on Astro's documentation standards.

### Changes

- Added dedicated handling for `404/` pathname to generate `404.html` at the root level
- This follows Astro's custom 404 error page convention as documented at https://docs.astro.build/en/basics/astro-pages/#custom-404-error-page

### Testing

- [x] Tested with `404.astro` page in the `src/pages/` folder

### Checklist

- [x] Create changeset
- [x] Code follows project style guidelines
- [x] Documentation has been updated if necessary
- [x] All tests pass
- [x] Commits are properly formatted and descriptive
- [x] PR targets appropriate branch