### PR TITLE
[astro-seo-meta] Add `siteName` to Facebook metadata component

### DIFF
--- a/.changeset/lovely-pumpkins-juggle.md
+++ b/.changeset/lovely-pumpkins-juggle.md
@@ -1,0 +1,5 @@
+---
+'astro-seo-meta': minor
+---
+
+Added the configuration for siteName in Facebook metadata, along with additional updates and modifications to other components.

--- a/packages/astro-seo-meta/README.md
+++ b/packages/astro-seo-meta/README.md
@@ -18,6 +18,12 @@ Install using pnpm:
 pnpm add astro-seo-meta
 ```
 
+or using bun:
+
+```bash
+bun add astro-seo-meta
+```
+
 Or using npm:
 
 ```bash
@@ -70,6 +76,7 @@ import { Seo } from "astro-seo-meta"
 | `facebook.image` | `false`  | `"/facebook.png"`                 | Facebook share image.                                             |
 | `facebook.url`   | `false`  | `"https://astro.build"`           | Page URL.                                                         |
 | `facebook.type`  | `false`  | `"website"`                       | Type of resource. See all types [here][types].                    |
+| `facebook.siteName` | `false` | `"astrodotbuild"`               | Name of the website displayed in Facebook sharing metadata.       |
 | `twitter.image`  | `false`  | `"/twitter.png"`                  | Twitter share image.                                              |
 | `twitter.site`   | `false`  | `"@astrodotbuild"`                | Twitter handle of the publishing site.                            |
 | `twitter.card`   | `false`  | `"summary"`                       | Format of Twitter share card. See all types [here][cards].        |
@@ -93,6 +100,7 @@ All of the `Seo` props are optional. If a prop is not provided, the associated m
     image: "/facebook.png",
     url: "https://astro.build",
     type: "website",
+    siteName: 'astrodotbuild'
   }}
   twitter={{
     image: "/twitter.png",

--- a/packages/astro-seo-meta/src/Facebook.astro
+++ b/packages/astro-seo-meta/src/Facebook.astro
@@ -19,9 +19,10 @@ export interface Props {
   description?: string;
   image?: string;
   type?: ObjectType;
+  siteName?: string;
 }
 
-const { url, type, title, description, image } = Astro.props;
+const { url, type, title, description, image, siteName } = Astro.props;
 ---
 
 <Fragment>
@@ -30,4 +31,5 @@ const { url, type, title, description, image } = Astro.props;
   {title && <meta property="og:title" content={title} />}
   {description && <meta property="og:description" content={description} />}
   {image && <meta property="og:image" content={image} />}
+  {siteName && <meta property="og:site_name" content={siteName} />}
 </Fragment>

--- a/packages/astro-seo-meta/src/Seo.astro
+++ b/packages/astro-seo-meta/src/Seo.astro
@@ -10,7 +10,7 @@ export interface Props {
   icon?: string;
   themeColor?: string;
   colorScheme?: MetaProps['colorScheme'];
-  facebook?: Pick<FacebookProps, 'image' | 'type' | 'url'>;
+  facebook?: Pick<FacebookProps, 'image' | 'type' | 'url' | 'siteName'>;
   twitter?: Pick<TwitterProps, 'image' | 'card' | 'site'>;
   robots?: string;
 }
@@ -44,6 +44,7 @@ const {
     image={facebook?.image}
     url={facebook?.url}
     type={facebook?.type}
+    siteName={facebook?.siteName}
   />
   <Twitter
     title={title}


### PR DESCRIPTION
## Update Details

We have added the `siteName` feature in the **Facebook Meta** of the `Seo.astro` and `Facebook.astro` files. This feature allows specifying the website's name in Facebook metadata, improving the display of shared content on the Facebook platform.

### Added Features

| Feature         | Updated Files       | Description                               |
| :-------------- | :------------------ | :---------------------------------------- |
| `siteName`      | `Seo.astro`         | Added support for specifying the website name in Facebook metadata. |
| `siteName`      | `Facebook.astro`    | Supports adding `siteName` for displaying the website name.          |

---

## Update Timeline

```plaintext
📅 2025-01-17: Added `siteName` feature in Facebook Meta
    - Updated Files: `Seo.astro`, `Facebook.astro`
    - Feature: Added support for `siteName` in metadata for displaying the website name on Facebook.
```