### PR TITLE
fix(astro-purgecss): fix globs passed to purgecss on windows

### DIFF
--- a/.changeset/eager-yaks-sip.md
+++ b/.changeset/eager-yaks-sip.md
@@ -1,0 +1,5 @@
+---
+'astro-purgecss': patch
+---
+
+fix handling of globs for purgecss on windows

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -60,13 +60,14 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
         }
 
         // Run PurgeCSS on all CSS files
+        // Replace is needed to make sure to pass correct glob format on windows machines
         const purgeResults = await new PurgeCSS().purge({
-          css: [join(outDir, '/**/*.css')],
+          css: [`${outDir}/**/*.css`.replace(/\\/g, '/')],
           defaultExtractor,
           ...options,
           content: [
-            join(outDir, '/**/*.html'),
-            join(outDir, '/**/*.js'),
+            `${outDir}/**/*.html`.replace(/\\/g, '/'),
+            `${outDir}/**/*.js`.replace(/\\/g, '/'),
             ...(options.content || [])
           ]
         });


### PR DESCRIPTION
When bumping `atro-purgecss` from 4.6.1 to 5.2.0, I realized it stopped working on windows. It is no longer detecting correctly the `content` files for `purgecss`. The issue is reproable in the `apps/example-purgecss`, check screenshot below:

![image](https://github.com/user-attachments/assets/ecd5631e-9b93-4349-971c-423856dd478d)

Turns out, when passing globs to purgecss for `content` and `css` options, they need to use forward slashes. In scope of this PR, we replace backward slashes with forward slashes in the globs passed to purgecss, fixing the issue on windows machine and having no impact on linux based systems.

I verified the change both in codespace and on my local windows machine;

![image](https://github.com/user-attachments/assets/78fe3fcc-428b-4938-90ee-6f9154b85767)
