### PR TITLE
fix(astro-purgecss): fix file path replacement on windows

### DIFF
--- a/.changeset/cold-places-drum.md
+++ b/.changeset/cold-places-drum.md
@@ -1,0 +1,5 @@
+---
+'astro-purgecss': patch
+---
+
+Fix issue with path replacement on windows

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -182,12 +182,10 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
               let content = await readFileContent(htmlFile);
 
               for (const { oldFilename, newFilename } of changedFiles) {
-                if (content.includes(oldFilename)) {
-                  content = content.replace(
-                    new RegExp(oldFilename, 'g'),
-                    newFilename
-                  );
-                }
+                const normalizedOldPath = oldFilename.replace(/\\/g, '/');
+                const normalizedNewPath = newFilename.replace(/\\/g, '/');
+                
+                content = content.replace(new RegExp(normalizedOldPath, 'g'), normalizedNewPath);
               }
 
               await writeFileContent(htmlFile, content);


### PR DESCRIPTION
Yesterday, while working on #930 I just checked the output of the command, instead of checking actually what happens after running `astro preview`. Turns out, on Windows it was still broken, as replacing file path was not working due to paths not matching on windows.

In scope of this PR we make sure path replacement is platform agnostic, so that it works both on Linux and Windows. 
Verified the change by running `pnpm run build && pnpm run preview` in `apps/example-purgecss` and verifying css is loaded correctly.

Before the change:

![image](https://github.com/user-attachments/assets/8d3778de-7981-486d-804c-30c90bf8e832)

After the change:

![image](https://github.com/user-attachments/assets/fbb647fa-8d8d-46b8-b491-74a5dfe8614f)
