### PR TITLE
fix(astro-purgecss): add compatibility with PandaCSS

### DIFF
--- a/.changeset/moody-pianos-feel.md
+++ b/.changeset/moody-pianos-feel.md
@@ -1,0 +1,5 @@
+---
+'astro-purgecss': patch
+---
+
+Fix compatibility with CSS selectors in PandaCSS.

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -25,7 +25,7 @@ const INTEGRATION_NAME = 'astro-purgecss' as const;
  * @param content string
  */
 const defaultExtractor = (content: string) =>
-  content.match(/[\w-/:]+(?<!:)/g) || [];
+  content.match(/[\w-/:\.#\(\),';%]+(?<!:)/g) || [];
 
 /**
  * Astro integration for PurgeCSS that removes unused CSS from the final build


### PR DESCRIPTION
PandaCSS generates CSS classes with characters allowed in the CSS standard, but these are not included in the extractor.