### PR TITLE
[astro-purgecss] Fix broken path handling on Windows

### DIFF
--- a/.changeset/clever-spiders-pick.md
+++ b/.changeset/clever-spiders-pick.md
@@ -1,0 +1,5 @@
+---
+'astro-purgecss': patch
+---
+
+Fix broken path handling on Windows

--- a/packages/astro-purgecss/src/index.ts
+++ b/packages/astro-purgecss/src/index.ts
@@ -1,6 +1,6 @@
 import type { AstroConfig, AstroIntegration } from 'astro';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { PurgeCSS, type UserDefinedOptions, type RawContent } from 'purgecss';
 
@@ -140,7 +140,7 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
           await Promise.all(
             purgedCssFiles.map(async ({ css, file }) => {
               await writeCssFile(file, css, file);
-              success(file.replace(outDir, ''));
+              success(relative(outDir, file));
             })
           );
           logger.info('🎉 Purging completed successfully!');
@@ -156,7 +156,7 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
             // ex: assets/styles/light.css
             if (!isAssetFile) {
               await writeCssFile(file, css, file);
-              const relativePath = file.replace(outDir, '');
+              const relativePath = relative(outDir, file);
               success(relativePath);
               return {
                 oldFilename: relativePath,
@@ -168,8 +168,8 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
             const hashedFilename = generateFileHash(file, css);
             await writeCssFile(hashedFilename, css, file);
 
-            const relativeOldPath = file.replace(outDir, '');
-            const relativeNewPath = hashedFilename.replace(outDir, '');
+            const relativeOldPath = relative(outDir, file);
+            const relativeNewPath = relative(outDir, hashedFilename);
             success(relativeNewPath);
 
             return {
@@ -251,7 +251,7 @@ function Plugin(options: PurgeCSSOptions = {}): AstroIntegration {
               }
 
               await writeFileContent(htmlFile, content);
-              success(htmlFile.replace(outDir, ''));
+              success(relative(outDir, htmlFile));
             })
           );
         }

--- a/packages/astro-purgecss/src/utils.ts
+++ b/packages/astro-purgecss/src/utils.ts
@@ -44,14 +44,14 @@ export function generateFileHash(filePath: string, content: string) {
   return `${filePath.slice(0, -13)}.${hash}.css`;
 }
 
-// Clean from extra slash on windows and trailing forward slash on non-windows
+// Clean from trailing slash and extra leading slash on windows
 export function cleanPath(file: URL): string {
   if (!(file instanceof URL)) {
     throw new TypeError('Expected a URL object');
   }
 
-  // Remove trailing forward slash if present
-  let path = fileURLToPath(file).replace(/\/+$/, '');
+  // Remove trailing slash if present
+  let path = fileURLToPath(file).replace(/(?:\/+|\\+)$/, '');
 
   // Remove leading forward slash on windows if present
   return process.platform === 'win32' ? path.replace(/^\/+/, '') : path;


### PR DESCRIPTION
After upgrading to v6.0.0, `astro-purgecss` breaks static site builds on Windows. Purged CSS files are rehashed but the changed file names are not updated in the asset files referencing them. This results in unstyled pages.

The root cause of the issue is that it seems like something has changed in Astro v6 so it returns the output directory path in the `astro:build:done` hook with backslashes, including a trailing backslash. This breaks the current logic that creates relative file paths.

I suggest using Node.js's built-in [`path.relative`](https://nodejs.org/api/path.html#pathrelativefrom-to) function instead as it should be a more robust way to create relative file paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling and normalization across CSS processing so references, asset updates, and success logs use correct relative paths.
  * Fixed trailing-slash handling on Windows to prevent incorrect path formatting and mismatched CSS references.

* **Chores**
  * Added a patch release note entry to mark the fix for cross-platform path issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->